### PR TITLE
Fixed problem with argument return

### DIFF
--- a/src/com/modcrafting/ultrabans/commands/Unban.java
+++ b/src/com/modcrafting/ultrabans/commands/Unban.java
@@ -36,7 +36,7 @@ public class Unban extends CommandHandler {
 
 	public String command(CommandSender sender, Command command, String[] args) {
 		if (args.length < 1)
-			return lang.getString("Ban.Arguments");
+			return lang.getString("Unban.Arguments");
 		boolean broadcast = true;
 		String admin = Ultrabans.DEFAULT_ADMIN;
 		String reason;


### PR DESCRIPTION
Was returning ban argument, instead of unban. Changed from "ban.arguments" to "unban.arguments"
