### PR TITLE
Add "MaxWarning.ClearWarns" property to config + Database fix

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,8 @@ MaxWarning:
   Result: ban
   Silent: true
   Reason: 'Max Warnings'
+  #Clear warnings of player when player reach max warnings?#
+  ClearWarns: true
   #Used with Temporary actions#
   Temp:
     Amt: 5

--- a/src/com/modcrafting/ultrabans/commands/Warn.java
+++ b/src/com/modcrafting/ultrabans/commands/Warn.java
@@ -15,12 +15,17 @@
  */
 package com.modcrafting.ultrabans.commands;
 
+import java.util.List;
+
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
 import com.modcrafting.ultrabans.Ultrabans;
+import com.modcrafting.ultrabans.util.BanInfo;
+import com.modcrafting.ultrabans.util.BanType;
 import com.modcrafting.ultrabans.util.Formatting;
 
 public class Warn extends CommandHandler {
@@ -101,6 +106,10 @@ public class Warn extends CommandHandler {
 					String fakecmd = "ban" + " " + idoit + " " + "-s" + " " + r;
 					plugin.getServer().dispatchCommand(sender, fakecmd);
 				}
+				
+				if(config.getBoolean("MaxWarning.ClearWarns"))
+					plugin.getAPI().clearWarn(idoit);
+				
 				return null;
 			}	
 		}

--- a/src/com/modcrafting/ultrabans/commands/Warn.java
+++ b/src/com/modcrafting/ultrabans/commands/Warn.java
@@ -15,8 +15,6 @@
  */
 package com.modcrafting.ultrabans.commands;
 
-import java.util.List;
-
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/com/modcrafting/ultrabans/db/Database.java
+++ b/src/com/modcrafting/ultrabans/db/Database.java
@@ -292,6 +292,7 @@ public abstract class Database {
 			connection = getSQLConnection();
 			PreparedStatement ps = connection.prepareStatement("DELETE FROM " + bantable + " WHERE name = ? AND type = 2");
 			ps.setString(1, player);
+			ps.executeUpdate();
 			close(ps, null);
 		} catch (SQLException ex) {
 			Error.execute(plugin, ex);


### PR DESCRIPTION
If MaxWarning.ClearWarns is true, then when player reach maxwarning, UB will proceed punishment chose in "MaxWarning" and clear all warnings of player.

Database fix: In database you probably forget call ps.executeUpdate() in method clearWarns in Class Database

PS: Sorry for bad English, I'm from Czech.
